### PR TITLE
pushed VITE frontend error

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,6 +35,6 @@ services:
           - API=http://localhost:5000
         volumes:
           - ./client/:/app
-        command: npm run dev
+        command: sh -c "npm rebuild esbuild && npm run dev"
       
 


### PR DESCRIPTION
This patches the wrong esbuild version in the docker run. Anyone plagued with the error saying "trying to install for esbuild-darwin-64 blahblha blha" should now be able to run properly.