### PR TITLE
Route to edit user fields 

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ If password is wrong: respond with 401 with message "wrong password"
 
 `/user/email/<email>`: get users identified by email (returns array of User objects)
 
+`/user/edit/<mongo_id>`: edit a user with given mongo_id with fields in request body JSON (used for updating only mutable fields preferredName and profileImgDir)
+
 #### Goal Routes
 
 `/goal/list`: get all goals (returns array of Goal objects)

--- a/server/src/db/controllers/userController.js
+++ b/server/src/db/controllers/userController.js
@@ -76,3 +76,11 @@ exports.find_employees_by_manager = (req, res) => {
 
 }
 
+
+//edit a user's mutable fields by mongo_id
+exports.edit_user = (req, res) =>{
+    User.findByIdAndUpdate(req.params.mongo_id, req.body, {new: true})
+    .then((data) => sendData(res,data))
+    .catch((e)=> onServerError(res,e))
+
+}

--- a/server/src/db/schemas/userSchema.js
+++ b/server/src/db/schemas/userSchema.js
@@ -2,19 +2,64 @@ const mongoose = require('mongoose');
 
 const userSchema = new mongoose.Schema(
 	{
-		firstName: { type: String, required: true },
-		lastName: { type: String, required: true },
-		employeeId:Number,
-        email: { type: String, required: true },
-		companyId:Number,
-		companyName : String,
-        managerId:Number,
-		positionTitle: String,
-		startDate:String,
-		isManager: { type: Boolean, required: true },
-		password: { type: String, required: true },
-        preferredName: String,
-        profileImageDir: {type:Buffer,contentType:String}
+		firstName: { 
+			type: String, 
+			required: true,
+			immutable: true 
+		},
+		lastName: { 
+			type: String, 
+			required: true,
+			immutable: true
+		},
+		employeeId:{
+			type: Number,
+			immutable: true
+		},
+        email: { 
+			type: String, 
+			required: true,
+			immutable: true 
+		},
+		companyId:{
+			type: Number,
+			immutable: true
+		},
+		companyName : {
+			type: String,
+			immutable: true
+		},
+        managerId:{
+			type: Number,
+			immutable: true
+		},
+		positionTitle: {
+			type: String,
+			immutable: true
+		},
+		startDate:{
+			type: String,
+			immutable: true
+		},
+		isManager: { 
+			type: Boolean, 
+			required: true,
+			immutable: true	
+		},
+		password: { 
+			type: String, 
+			required: true,
+			immutable: true
+		},
+        preferredName: {
+			type: String,
+			immutable: false
+		},
+        profileImageDir: {
+			type: Buffer,
+			contentType: String,
+			immutable: false
+		}
 	},
 	{ timestamps: true }
 )

--- a/server/src/routes/user.js
+++ b/server/src/routes/user.js
@@ -68,12 +68,10 @@ router.get("/email/:email", user_controller.find_user_by_email)
 
 //UPDATE
 
-module.exports=router
-
-
-//EDIT
-
 /*
 edit a user's mutable fields by replacing with fields in request body
+note: will only change mutable User fields, even if request body specifies immutable fields
 */
 router.post("/edit/:mongo_id", auth, user_controller.edit_user)
+
+module.exports=router

--- a/server/src/routes/user.js
+++ b/server/src/routes/user.js
@@ -69,3 +69,11 @@ router.get("/email/:email", user_controller.find_user_by_email)
 //UPDATE
 
 module.exports=router
+
+
+//EDIT
+
+/*
+edit a user's mutable fields by replacing with fields in request body
+*/
+router.post("/edit/:mongo_id", auth, user_controller.edit_user)


### PR DESCRIPTION
Route to edit user fields. For safety (Sage's idea) I changed the user schema so that only "preferredName" and "profileImageDir" fields are mutable. The charter was not very clear on what fields should be mutable by the user but common sense says a lot of them should not be. Changing the schema shouldn't be totally necessary as the front-end would not provide the capability to change "positionTitle" for example, but it's probably good practice to make the schema change anyways. 

I tested the route using Postman:
POST: localhost:5000/user/edit/63600d0521922d31d8a74f9b
JSON body: {
    "preferredName": "G-Man",
    "firstName": "test name"
} 

This successfully changes the preferred name of user 63600d0521922d31d8a74f9b. While the command attempts to change the "firstName" field nothing happens to it as that field is immutable.  


