### PR TITLE
Added goal category enum

### DIFF
--- a/server/src/db/schemas/goalSchema.js
+++ b/server/src/db/schemas/goalSchema.js
@@ -5,7 +5,7 @@ const goalSchema=new mongoose.Schema({
 	description:{ type: String, required: true },
 	startDate:Date,
 	endDate:Date,
-	category:String,
+	category:{type: String, enum:["personal", "professional", "development"], required: true},
     status: {type: String, enum:["inactive", "active", "complete"], default: "inactive"},
 	poster:{
 		type: mongoose.Types.ObjectId,

--- a/server/src/db/schemas/goalSchema.js
+++ b/server/src/db/schemas/goalSchema.js
@@ -5,7 +5,7 @@ const goalSchema=new mongoose.Schema({
 	description:{ type: String, required: true },
 	startDate:Date,
 	endDate:Date,
-	category:{type: String, enum:["personal", "professional", "development"], required: true},
+	category:{type: String, enum:["personal", "performance", "developmental"], required: true},
     status: {type: String, enum:["inactive", "active", "complete"], default: "inactive"},
 	poster:{
 		type: mongoose.Types.ObjectId,


### PR DESCRIPTION
Changed from any string to the three categories listed in the charter (personal, professional, development)

Currently set as required with no default value. Feel free to change based on fronted implementation. 