### PR TITLE
Switch name of DB in use

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -15,8 +15,6 @@ services:
         container_name: api
         environment:
            - SERVER_PORT=5000
-           #- CONNECTION_STRING=mongodb+srv://yejoonjung:1357@cs320projecttest.t9mhlqf.mongodb.net/?retryWrites=true&w=majority
-           #- CONNECTION_STRING=mongodb+srv://GoalsForGordon:YEoH16H21y6jwVF1@goals-testing.gl51g8n.mongodb.net/?retryWrites=true&w=majority
 
         # Bind-Mount all files in code directory to accomodate nodemon and debuggers.
         volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,8 +15,6 @@ services:
         container_name: api
         environment:
            - SERVER_PORT=5000
-           #- CONNECTION_STRING=mongodb+srv://yejoonjung:1357@cs320projecttest.t9mhlqf.mongodb.net/?retryWrites=true&w=majority
-           #- CONNECTION_STRING=mongodb+srv://GoalsForGordon:YEoH16H21y6jwVF1@goals-testing.gl51g8n.mongodb.net/?retryWrites=true&w=majority
 
         # Bind-Mount all files in code directory to accomodate nodemon and debuggers.
         volumes:

--- a/server/src/db/index.js
+++ b/server/src/db/index.js
@@ -5,7 +5,7 @@ const { userSchema, goalSchema, commentSchema } = require('./schemas')
 const util=require('./../util')
 
 
-const MONGODB_URL = process.env.MONGODB_URL2
+const MONGODB_URL = process.env.MONGODB_URL
 
 mongoose.connect(MONGODB_URL)
 


### PR DESCRIPTION
Switched MONGODB_URL2 to MONGODB_URL (.env file now only contains single link to DB already in use in main, just renamed)

Commented out DB URI's in docker-compose files

This means everyone must update their .env file to match the changes.